### PR TITLE
loader[test: regex code]

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ var config = {
     module: {
         loaders: [
             {
-                test: /\.js?/,
+                test: /\.jsx?$/,
                 include: SRC_DIR,
                 loader: "babel-loader",
                 query: {


### PR DESCRIPTION
You commented that you'd changed it in next video, but it isn't mentioned here.  (FYI: My terminal doesn't run despite changing this - it says "ERROR in ./src/app/index.js" Module build failed: Error: Cannot find module 'babel-core'.  Drat!)