### PR TITLE
babel-core added as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^15.2.1"
   },
   "devDependencies": {
+    "babel-core": "^6.24.1",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",


### PR DESCRIPTION
Seems like you have babel-core globally installed, and thus all the projects in here seems to fail. Adding this would ensure compilation of the JSX.